### PR TITLE
Fix cookie handling for OAuth across domains

### DIFF
--- a/src/app/api/auth/google-callback/route.ts
+++ b/src/app/api/auth/google-callback/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getTokensFromCode, getUserInfo } from '@/lib/google-oauth';
-import { signAuthToken, getRoleBasedRedirect } from '@/lib/auth';
+import { signAuthToken, getRoleBasedRedirect, buildAuthCookieOptions } from '@/lib/auth';
 import { detectGoogleClassroomRole } from '@/lib/google';
 
 export async function GET(req: NextRequest) {
@@ -70,16 +70,11 @@ export async function GET(req: NextRequest) {
 		console.log('JWT token created');
 
 		// Create response with redirect
-		const res = NextResponse.redirect(new URL(redirectPath, req.url));
+                const redirectUrl = new URL(redirectPath, req.url);
+                const res = NextResponse.redirect(redirectUrl);
 
-		// Set authentication cookie
-		res.cookies.set('token', token, {
-			httpOnly: true,
-			secure: process.env.NODE_ENV === 'production',
-			sameSite: 'lax',
-			path: '/',
-			maxAge: 60 * 60 * 24 * 7, // 7 days
-		});
+                // Set authentication cookie
+                res.cookies.set('token', token, buildAuthCookieOptions(redirectUrl.hostname));
 
 		console.log('Redirecting to:', redirectPath);
 		return res;

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { signAuthToken, verifyStaticCredentials } from '@/lib/auth';
+import { buildAuthCookieOptions, signAuthToken, verifyStaticCredentials } from '@/lib/auth';
 
 export async function POST(req: NextRequest) {
 	const { username, password } = await req.json();
@@ -15,12 +15,6 @@ export async function POST(req: NextRequest) {
 
 	const token = signAuthToken({ email: username, role: 'super-admin', userId: username });
 	const res = NextResponse.json({ success: true });
-	res.cookies.set('token', token, {
-		httpOnly: true,
-		secure: true,
-		sameSite: 'lax',
-		path: '/',
-		maxAge: 60 * 60 * 24 * 7,
-	});
+        res.cookies.set('token', token, buildAuthCookieOptions(req.nextUrl.hostname));
 	return res;
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,16 +1,12 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { buildAuthCookieOptions } from '@/lib/auth';
 
-export async function POST() {
-	const res = NextResponse.json({ success: true });
-	
-	// Clear the authentication cookie
-	res.cookies.set('token', '', {
-		httpOnly: true,
-		secure: process.env.NODE_ENV === 'production',
-		sameSite: 'lax',
-		path: '/',
-		maxAge: 0, // Expire immediately
-	});
+export async function POST(req: NextRequest) {
+        const res = NextResponse.json({ success: true });
 
-	return res;
+        // Clear the authentication cookie
+        const options = buildAuthCookieOptions(req.nextUrl.hostname, 0);
+        res.cookies.set('token', '', options);
+
+        return res;
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken';
 const JWT_SECRET = process.env.JWT_SECRET as string;
 const ADMIN_USERNAME = process.env.ADMIN_USERNAME as string;
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD as string;
+const AUTH_COOKIE_DOMAIN = process.env.AUTH_COOKIE_DOMAIN;
 
 if (!JWT_SECRET) {
 	throw new Error('Please define JWT_SECRET in .env.local');
@@ -13,15 +14,72 @@ export function verifyStaticCredentials(username: string, password: string): boo
 }
 
 export interface AuthTokenPayload {
-	email: string;
-	role: 'student' | 'teacher' | 'district-admin' | 'super-admin';
-	userId?: string;
-	accessToken?: string;
-	refreshToken?: string;
+        email: string;
+        role: 'student' | 'teacher' | 'district-admin' | 'super-admin';
+        userId?: string;
+        accessToken?: string;
+        refreshToken?: string;
 }
 
 export function signAuthToken(payload: AuthTokenPayload): string {
-	return jwt.sign(payload, JWT_SECRET, { expiresIn: '7d' });
+        return jwt.sign(payload, JWT_SECRET, { expiresIn: '7d' });
+}
+
+type CookieOptions = {
+        httpOnly?: boolean;
+        secure?: boolean;
+        sameSite?: 'strict' | 'lax' | 'none';
+        path?: string;
+        maxAge?: number;
+        domain?: string;
+};
+
+function deriveCookieDomain(hostname?: string): string | undefined {
+        if (AUTH_COOKIE_DOMAIN) {
+                return AUTH_COOKIE_DOMAIN;
+        }
+
+        if (!hostname) {
+                return undefined;
+        }
+
+        const lowerHost = hostname.toLowerCase();
+
+        // Skip localhost or IP addresses, they should remain host-only cookies
+        if (lowerHost === 'localhost' || /^\d{1,3}(\.\d{1,3}){3}$/.test(lowerHost)) {
+                return undefined;
+        }
+
+        const hostParts = lowerHost.split('.');
+
+        if (hostParts.length === 2) {
+                // Already an apex domain (e.g. example.com)
+                return lowerHost;
+        }
+
+        if (hostParts.length === 3 && hostParts[hostParts.length - 2].length > 3) {
+                // Common subdomain pattern (e.g. app.example.com)
+                return hostParts.slice(-2).join('.');
+        }
+
+        return undefined;
+}
+
+export function buildAuthCookieOptions(hostname?: string, maxAge = 60 * 60 * 24 * 7): CookieOptions {
+        const options: CookieOptions = {
+                httpOnly: true,
+                secure: process.env.NODE_ENV === 'production',
+                sameSite: 'lax',
+                path: '/',
+                maxAge,
+        };
+
+        const domain = deriveCookieDomain(hostname);
+        if (domain) {
+                options.domain = domain;
+        }
+
+        return options;
 }
 
 export function getRoleBasedRedirect(role: string): string {


### PR DESCRIPTION
## Summary
- add shared helper for building authentication cookie options
- update OAuth callback, static login, and logout handlers to use domain-aware cookie settings
- support configuring the auth cookie domain for custom deployments

## Testing
- npm run lint *(fails: missing dependency @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_b_68fc60008bc08321a697486343040d03